### PR TITLE
feat(audio): Corsair VOID Elite auto-switch + portable Arch installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ reinstall_dotfiles
 - ✅ **WSL** (Windows Subsystem for Linux)
 - ✅ **macOS** (shell and tool configs, package installation not automated)
 
+## Corsair headset auto-switch
+
+`bin/corsair-headset-switch` is a systemd user service that switches the default
+PipeWire sink to the Corsair VOID Elite when the headset powers on and restores
+the previous sink when it powers off. It depends on `headsetcontrol` (installed
+by `setup.sh`). After symlinking, enable it once:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now corsair-headset.service
+```
+
+Logs: `journalctl --user -u corsair-headset -f`.
+
 ## 📝 License
 
 Personal dotfiles - use at your own discretion.

--- a/bin/corsair-headset-switch
+++ b/bin/corsair-headset-switch
@@ -4,8 +4,6 @@ set -uo pipefail
 readonly VOID_SINK_PATTERN='VOID_ELITE'
 readonly POLL_INTERVAL=2
 
-# Map headsetcontrol JSON (stdin) to on|off|unknown. Unknown covers empty or
-# unparseable input so a transient query failure never flips the default sink.
 parse_headset_state() {
   local json status
   json="$(cat)"
@@ -18,14 +16,12 @@ parse_headset_state() {
   esac
 }
 
-# Current headset power state, or "unknown" if headsetcontrol fails.
 headset_state() {
   local json
   json="$(headsetcontrol -o json 2>/dev/null)" || { echo unknown; return; }
   parse_headset_state <<<"${json}"
 }
 
-# PipeWire sink name for the VOID dongle, empty if not present.
 void_sink() {
   pactl list short sinks | awk -v p="${VOID_SINK_PATTERN}" '$0 ~ p { print $2; exit }'
 }
@@ -70,7 +66,7 @@ main() {
         fi
         prev=off
         ;;
-      *) : ;; # unknown: hold state, do nothing
+      *) : ;;
     esac
     sleep "${POLL_INTERVAL}"
   done

--- a/bin/corsair-headset-switch
+++ b/bin/corsair-headset-switch
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+readonly VOID_SINK_PATTERN='VOID_ELITE'
+readonly POLL_INTERVAL=2
+
+# Map headsetcontrol JSON (stdin) to on|off|unknown. Unknown covers empty or
+# unparseable input so a transient query failure never flips the default sink.
+parse_headset_state() {
+  local json status
+  json="$(cat)"
+  [[ -n "${json}" ]] || { echo unknown; return; }
+  status="$(jq -r '.devices[0].battery.status // empty' <<<"${json}" 2>/dev/null)"
+  case "${status}" in
+    BATTERY_AVAILABLE | BATTERY_CHARGING) echo on ;;
+    BATTERY_UNAVAILABLE | BATTERY_TIMEOUT) echo off ;;
+    *) echo unknown ;;
+  esac
+}
+
+# Current headset power state, or "unknown" if headsetcontrol fails.
+headset_state() {
+  local json
+  json="$(headsetcontrol -o json 2>/dev/null)" || { echo unknown; return; }
+  parse_headset_state <<<"${json}"
+}
+
+# PipeWire sink name for the VOID dongle, empty if not present.
+void_sink() {
+  pactl list short sinks | awk -v p="${VOID_SINK_PATTERN}" '$0 ~ p { print $2; exit }'
+}
+
+log() { printf '%s %s\n' "$(date '+%H:%M:%S')" "$*"; }
+
+main() {
+  command -v headsetcontrol >/dev/null || { echo 'headsetcontrol not found' >&2; exit 1; }
+  command -v jq >/dev/null || { echo 'jq not found' >&2; exit 1; }
+  command -v pactl >/dev/null || { echo 'pactl not found' >&2; exit 1; }
+
+  local prev current sink saved_default=''
+  prev="$(headset_state)"
+  [[ "${prev}" == unknown ]] && prev=off
+  log "baseline headset state: ${prev}"
+
+  while true; do
+    current="$(headset_state)"
+    case "${current}" in
+      on)
+        if [[ "${prev}" == off ]]; then
+          sink="$(void_sink)"
+          if [[ -n "${sink}" ]]; then
+            saved_default="$(pactl get-default-sink)"
+            pactl set-default-sink "${sink}"
+            log "headset on -> default sink = ${sink} (was ${saved_default})"
+          else
+            log 'headset on but VOID sink not found; skipping'
+          fi
+        fi
+        prev=on
+        ;;
+      off)
+        if [[ "${prev}" == on ]]; then
+          if [[ -n "${saved_default}" ]] \
+            && pactl list short sinks | awk '{print $2}' | grep -qxF "${saved_default}"; then
+            pactl set-default-sink "${saved_default}"
+            log "headset off -> restored default sink = ${saved_default}"
+          else
+            log 'headset off but no valid previous sink to restore'
+          fi
+        fi
+        prev=off
+        ;;
+      *) : ;; # unknown: hold state, do nothing
+    esac
+    sleep "${POLL_INTERVAL}"
+  done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -47,6 +47,7 @@ init_links() {
     move_link .config/spotifyd/spotifyd.conf media/spotifyd.conf
     move_link .config/fontconfig fontconfig
     move_link .config/ngrok/ngrok.yml web/ngrok.yml
+    move_link .config/systemd/user/corsair-headset.service systemd/corsair-headset.service
 
     echo "Symlinking complete. Backups stored in ${SCRIPT_PATH}/backups."
     return

--- a/setup.sh
+++ b/setup.sh
@@ -67,7 +67,7 @@ install_packages() {
     return
   fi
 
-  if grep --quiet 'ID=manjaro' /etc/os-release; then
+  if is_arch; then
     # shellcheck disable=2119
     install_arch_packages
     post_install_packages

--- a/shell/functions
+++ b/shell/functions
@@ -62,7 +62,7 @@ reinstall_dotfiles() {
 
 install_arch_packages() {
   echo 'Enabling the AUR...'
-  sudo sed -Ei '/EnableAUR/s/^#//' /etc/pamac.conf
+  enable_aur
 
   PACKAGES=(
     # General
@@ -148,11 +148,7 @@ install_arch_packages() {
     bat
   )
 
-  # shellcheck disable=2046
-  sudo pamac install --no-confirm --no-upgrade $(
-    IFS=' '
-    echo "${PACKAGES[*]}"
-  ) "$@"
+  arch_install "${PACKAGES[@]}" "$@"
 }
 
 install_wsl_packages() {
@@ -440,7 +436,7 @@ post_install_packages() {
   echo 'Installing `spotify-tui'
   mkdir "${HOME}/.rustup"
   rustup default stable
-  pamac install --no-confirm --no-upgrade spotify-tui
+  arch_install spotify-tui
 }
 
 post_setup_arch_services() {
@@ -450,7 +446,7 @@ post_setup_arch_services() {
 }
 
 setup_arch_system_emoji_support() {
-  sudo pamac install noto-fonts-emoji
+  arch_install noto-fonts-emoji
   sudo cp ~/.dotfiles/templates/fonts-local.conf /etc/fonts/local.conf
 }
 

--- a/shell/functions
+++ b/shell/functions
@@ -137,6 +137,7 @@ install_arch_packages() {
     tldr
     git
     jq
+    headsetcontrol
     ripgrep
     exa
     fd

--- a/shell/functions
+++ b/shell/functions
@@ -8,6 +8,53 @@ section_start() {
   echo "${1}"
 }
 
+# Detect the AUR helper once; prefer paru, then pamac, then yay.
+detect_aur_helper() {
+  local h
+  for h in paru pamac yay; do
+    if command -v "${h}" &>/dev/null; then
+      AUR_HELPER="${h}"
+      return 0
+    fi
+  done
+  echo 'No supported AUR helper (paru/pamac/yay) found' >&2
+  return 1
+}
+
+# Install packages via the detected helper. paru/yay must not run under sudo.
+# Set DRY=1 to print the resolved command instead of running it.
+arch_install() {
+  [[ -n "${AUR_HELPER:-}" ]] || detect_aur_helper || return 1
+  local cmd
+  case "${AUR_HELPER}" in
+    paru | yay) cmd=("${AUR_HELPER}" -S --noconfirm --needed "$@") ;;
+    pamac) cmd=(sudo pamac install --no-confirm --no-upgrade "$@") ;;
+    *) echo "Unknown AUR helper: ${AUR_HELPER}" >&2; return 1 ;;
+  esac
+  if [[ -n "${DRY:-}" ]]; then
+    echo "${cmd[*]}"
+    return 0
+  fi
+  "${cmd[@]}"
+}
+
+# Enable AUR support where the helper needs it (pamac only).
+enable_aur() {
+  [[ -n "${AUR_HELPER:-}" ]] || detect_aur_helper || return 1
+  [[ "${AUR_HELPER}" == pamac ]] || return 0
+  [[ -n "${DRY:-}" ]] && return 0
+  sudo sed -Ei '/EnableAUR/s/^#//' /etc/pamac.conf
+}
+
+# True on Arch and derivatives. Sourced in a subshell so os-release vars don't leak.
+# shellcheck disable=SC1091
+is_arch() {
+  local id id_like
+  id="$(. /etc/os-release 2>/dev/null && echo "${ID:-}")"
+  id_like="$(. /etc/os-release 2>/dev/null && echo "${ID_LIKE:-}")"
+  [[ "${id}" == arch ]] || [[ " ${id_like} " == *' arch '* ]]
+}
+
 reinstall_dotfiles() {
   rm -rf ~/.{local/bin,npm,nvm,zinit,go/bin,config/composer/vendor,nvim,config/nvim}
   cd ~/.dotfiles && ./setup.sh

--- a/shell/functions
+++ b/shell/functions
@@ -8,7 +8,6 @@ section_start() {
   echo "${1}"
 }
 
-# Detect the AUR helper once; prefer paru, then pamac, then yay.
 detect_aur_helper() {
   local h
   for h in paru pamac yay; do
@@ -21,15 +20,16 @@ detect_aur_helper() {
   return 1
 }
 
-# Install packages via the detected helper. paru/yay must not run under sudo.
-# Set DRY=1 to print the resolved command instead of running it.
 arch_install() {
   [[ -n "${AUR_HELPER:-}" ]] || detect_aur_helper || return 1
   local cmd
   case "${AUR_HELPER}" in
-    paru | yay) cmd=("${AUR_HELPER}" -S --noconfirm --needed "$@") ;;
-    pamac) cmd=(sudo pamac install --no-confirm --no-upgrade "$@") ;;
-    *) echo "Unknown AUR helper: ${AUR_HELPER}" >&2; return 1 ;;
+  paru | yay) cmd=("${AUR_HELPER}" -S --noconfirm --needed "$@") ;;
+  pamac) cmd=(sudo pamac install --no-confirm --no-upgrade "$@") ;;
+  *)
+    echo "Unknown AUR helper: ${AUR_HELPER}" >&2
+    return 1
+    ;;
   esac
   if [[ -n "${DRY:-}" ]]; then
     echo "${cmd[*]}"
@@ -38,7 +38,6 @@ arch_install() {
   "${cmd[@]}"
 }
 
-# Enable AUR support where the helper needs it (pamac only).
 enable_aur() {
   [[ -n "${AUR_HELPER:-}" ]] || detect_aur_helper || return 1
   [[ "${AUR_HELPER}" == pamac ]] || return 0
@@ -46,8 +45,6 @@ enable_aur() {
   sudo sed -Ei '/EnableAUR/s/^#//' /etc/pamac.conf
 }
 
-# True on Arch and derivatives. Sourced in a subshell so os-release vars don't leak.
-# shellcheck disable=SC1091
 is_arch() {
   local id id_like
   id="$(. /etc/os-release 2>/dev/null && echo "${ID:-}")"

--- a/systemd/corsair-headset.service
+++ b/systemd/corsair-headset.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Corsair VOID Elite auto-switch
+After=pipewire.service
+
+[Service]
+Type=simple
+ExecStart=%h/.dotfiles/bin/corsair-headset-switch
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## What

Two related changes.

### 1. Portable Arch package installer (Manjaro/pamac -> any Arch + paru)

The installer hard-assumed Manjaro/pamac, so it did nothing on CachyOS (`ID=cachyos`, ships `paru`). Now:

- New `shell/functions` helpers: `detect_aur_helper` (prefers `paru` -> `pamac` -> `yay`), `arch_install` (paru/yay without sudo, pamac with sudo), `enable_aur` (pamac-only AUR config), and `is_arch` (true on `ID=arch` or `ID_LIKE` containing `arch`).
- All former `pamac` call sites (`install_arch_packages`, `post_install_packages`, `setup_arch_system_emoji_support`) route through `arch_install`.
- `setup.sh` OS gate broadened from `ID=manjaro` to `is_arch`, so the Arch path runs on CachyOS/EndeavourOS/etc. WSL (apt) and macOS paths are unaffected.

### 2. Headset auto-switch daemon

The VOID Elite's USB dongle stays connected whether the headset is on or off, so neither udev nor PipeWire node events fire on power toggle. Detection instead polls `headsetcontrol -o json` for `.devices[0].battery.status`.

- `bin/corsair-headset-switch`: a `systemd --user` poll loop (2s). On power-on it sets the VOID Elite as the default PipeWire sink; on power-off it restores the previously-default sink. Edge-detected in memory; baseline state captured at startup so a restart never hijacks audio; transient query failures hold state rather than flipping the sink.
- `systemd/corsair-headset.service` unit, symlinked into `~/.config/systemd/user/` via a new `move_link` line.
- `headsetcontrol` added to the Arch package list.

## Enabling

`setup.sh` symlinks the unit; enable it once (kept manual, by design):

```bash
systemctl --user daemon-reload
systemctl --user enable --now corsair-headset.service
```

## Verification

- ShellCheck clean on `shell/functions` and `bin/corsair-headset-switch`.
- Live end-to-end on CachyOS: service active; powering the headset on switched the default sink to the VOID Elite, powering it off restored HDMI (confirmed in `journalctl --user -u corsair-headset`).