### PR TITLE
fix(shell): extend project_open scan to find nested-git projects

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           submodules: recursive
       - name: Run BATS tests
-        run: ./tests/bats/bin/bats tests/*.bats
+        run: ./bin/bats/bin/bats tests/*.bats
 
   lua:
     runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
-[submodule "tests/bats"]
-	path = tests/bats
+[submodule "bin/bats"]
+	path = bin/bats
 	url = https://github.com/bats-core/bats-core.git
 [submodule "tests/test_helper/bats-support"]
 	path = tests/test_helper/bats-support

--- a/shell/aliases
+++ b/shell/aliases
@@ -275,11 +275,16 @@ _project_open_root() {
 _project_open_scan() {
 	local root
 	root="$(_project_open_root)"
-	# Projects live at <root>/<category>/<project> and always hold a .git, so one
-	# find at that fixed depth lists them; submodules sit deeper and fall out.
-	find "${root}" -mindepth 3 -maxdepth 3 -name '.git' 2>/dev/null |
-		sed 's#/\.git$##' |
-		LC_ALL=C sort
+	{
+		# Direct repos: root/cat/proj/.git
+		find "${root}" -mindepth 3 -maxdepth 3 -name '.git' 2>/dev/null |
+			sed 's#/\.git$##'
+		# Nested repos: root/cat/proj/sub/.git → root/cat/proj
+		# Handles WordPress projects where bedrock/trellis hold the .git instead.
+		# Submodules at depth 5+ are still excluded.
+		find "${root}" -mindepth 4 -maxdepth 4 -name '.git' 2>/dev/null |
+			sed 's#/[^/]*/\.git$##'
+	} | LC_ALL=C sort -u
 }
 
 _project_open_cache_file() {

--- a/tests/project_open.bats
+++ b/tests/project_open.bats
@@ -13,9 +13,6 @@ setup() {
 	XDG_CACHE_HOME="$(temp_make)"
 	export XDG_CACHE_HOME
 
-	# Projects sit at <root>/<category>/<project> and always hold a .git.
-	# wordpress projects carry a .git alongside their bedrock/site app dir;
-	# vcpkg is a nested submodule (deeper) that must be excluded from scans.
 	mkdir -p \
 		"${ROOT}/mods/HoldFast/.git" \
 		"${ROOT}/mods/HoldFast/lib" \
@@ -24,7 +21,9 @@ setup() {
 		"${ROOT}/wordpress/acme/.git" \
 		"${ROOT}/wordpress/acme/site" \
 		"${ROOT}/wordpress/beta/.git" \
-		"${ROOT}/wordpress/beta/bedrock"
+		"${ROOT}/wordpress/beta/bedrock" \
+		"${ROOT}/wordpress/itineris/bedrock/.git" \
+		"${ROOT}/wordpress/itineris/trellis/.git"
 
 	# shell/aliases sources ${HOME}/.dotfiles/shell/os.sh, so point HOME at a
 	# temp dir whose .dotfiles symlinks to this repo. That lets the suite run
@@ -43,10 +42,10 @@ teardown() {
 	temp_del "${TEST_HOME}"
 }
 
-@test "scan finds category/project dirs and excludes nested submodules" {
+@test "scan finds category/project dirs and excludes itineris submodules" {
 	local out
 	out="$(_project_open_scan | sed "s#^${ROOT}/##" | LC_ALL=C sort | tr '\n' ',')"
-	assert_equal "${out}" "misc/khuey,mods/HoldFast,wordpress/acme,wordpress/beta,"
+	assert_equal "${out}" "misc/khuey,mods/HoldFast,wordpress/acme,wordpress/beta,wordpress/itineris,"
 }
 
 @test "po_refresh creates the cache file" {
@@ -106,6 +105,11 @@ teardown() {
 	assert_output "${ROOT}/wordpress/acme"
 }
 
+@test "resolve maps a itineris-git project (no root .git) to its path" {
+	run _project_open_resolve itineris
+	assert_output "${ROOT}/wordpress/itineris"
+}
+
 @test "resolve of an unknown name is empty" {
 	run _project_open_resolve nope
 	assert_output ''
@@ -115,7 +119,7 @@ teardown() {
 	po_refresh
 	local out
 	out="$(_project_open_projects | LC_ALL=C sort | tr '\n' ',')"
-	assert_equal "${out}" "HoldFast,acme,beta,khuey,"
+	assert_equal "${out}" "HoldFast,acme,beta,itineris,khuey,"
 }
 
 @test "targets lists a project's subdirs" {
@@ -162,6 +166,13 @@ teardown() {
 	local dir
 	dir="$(cd / && project_open acme >/dev/null 2>&1 && pwd)"
 	assert_equal "${dir}" "${ROOT}/wordpress/acme/site"
+}
+
+@test "project_open descends into bedrock for a itineris-git project" {
+	po_refresh
+	local dir
+	dir="$(cd / && project_open itineris >/dev/null 2>&1 && pwd)"
+	assert_equal "${dir}" "${ROOT}/wordpress/itineris/bedrock"
 }
 
 @test "project_open <name> <subdir> cds into the subdir" {


### PR DESCRIPTION
## Summary

- `project_open` autocomplete was missing WordPress projects (e.g. `clinimed`) whose `.git` directories live inside `bedrock/` and `trellis/` subdirectories rather than at the project root
- Extended `_project_open_scan` with a depth-4 pass that maps nested sub-repo paths back to their parent project directory, with `sort -u` to deduplicate
- Moved the `bats` submodule into `bin/bats/` alongside the other repo binaries

## Changes

- `shell/aliases`: add depth-4 `find` pass in `_project_open_scan`; deduplicate with `sort -u`
- `tests/project_open.bats`: add `clinimed`-style fixture (`.git` only in subdirs) and 2 new test cases
- `.gitmodules` / CI: relocate `bats` submodule from `tests/bats` to `bin/bats/`

## Testing

```
./bin/bats/bin/bats tests/project_open.bats
```